### PR TITLE
Feat: Added useHover hook

### DIFF
--- a/apps/playground/src/stories/hooks/useHover.stories.tsx
+++ b/apps/playground/src/stories/hooks/useHover.stories.tsx
@@ -1,0 +1,79 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { useHover } from '../../../../../packages/react-hooks/use-hover';
+// import { useHover } from "@nanlabs/react-hooks";
+
+export const Example = () => {
+  const [isCbMemoBroken, setIsCbMemoBroken] = useState(false);
+  const [isTargetMemoBroken, setTargetMemoBroken] = useState(false);
+  const [events, setEvents] = useState<string[]>([])
+
+  const getEventHandler = useCallback((eventName: string) => {
+    return () => setEvents((events) => [...events, `"${eventName}" callback fired`])
+  }, [setEvents])
+
+  const memoizedCallbacks = useMemo(
+    () => ({
+      onChange: getEventHandler('onChange'),
+      onLeave: getEventHandler('onLeave'),
+      onEnter: getEventHandler('onEnter'),
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [getEventHandler, isCbMemoBroken]
+  )
+
+  const notMemoizedCallbacks = {
+    onChange: getEventHandler('onChange'),
+    onLeave: getEventHandler('onLeave'),
+    onEnter: getEventHandler('onEnter'),
+  }
+  
+  const divRef = useRef<HTMLDivElement | null>(null)
+  const getEl = () => divRef.current;
+
+  const isHovered = useHover(
+    isTargetMemoBroken ? getEl : divRef,
+    isCbMemoBroken ? notMemoizedCallbacks : memoizedCallbacks
+  );
+
+  const hoverableStyles = {
+    width: 200,
+    height: 200,
+    backgroundColor: isHovered ? 'tomato' : 'rebeccapurple',
+    color: isHovered ? 'black' : 'white',
+    display: 'flex',
+    flexDirection: 'column' as const,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10
+  }
+
+  return <div style={{display: 'flex', gap: 10}}>
+    <div style={hoverableStyles} ref={divRef}>
+      <h2>
+        {isHovered ? 'Hovered' : 'Hover me'}
+      </h2>
+
+      <span>
+        <button onClick={() => setIsCbMemoBroken((val) => !val)}>
+          {isCbMemoBroken ? 'Callbacks change each render' : 'Callbacks memoized'}
+        </button>
+      </span>
+
+      <span>
+        <button onClick={() => setTargetMemoBroken((val) => !val)}>
+          {isTargetMemoBroken ? 'Target provided as function' : 'Target provided as ref'}
+        </button>
+      </span>
+    </div>
+    <div> Event log:
+      <ol>
+        {events.map((event, i) => <li key={i}>{event}</li>)}
+      </ol>
+    </div>
+  </div>;
+};
+
+export default {
+  title: 'React Hooks/useHover',
+  component: useHover,
+};

--- a/apps/playground/src/stories/hooks/useHover.stories.tsx
+++ b/apps/playground/src/stories/hooks/useHover.stories.tsx
@@ -16,7 +16,7 @@ export const Example = () => {
     onEnter: getEventHandler('onEnter'),
   }
 
-  const memoizedCallbacks = useMemo(() => ({...notMemoizedCallbacks}), [getEventHandler, isMemoEnabled])
+  const memoizedCallbacks = useMemo(() => ({...notMemoizedCallbacks}), [getEventHandler])
   
   const divRef = useRef<HTMLDivElement | null>(null)
   const getElement = () => divRef.current;
@@ -58,7 +58,7 @@ export const Example = () => {
     </div>
     <div> Event log:
       <ol>
-        {events.map((event, i) => <li key={i}>{event}</li>)}
+        {events.map((event, i) => <li key={`${event}-${i}`}>{event}</li>)}
       </ol>
     </div>
   </div>;

--- a/apps/playground/src/stories/hooks/useHover.stories.tsx
+++ b/apps/playground/src/stories/hooks/useHover.stories.tsx
@@ -1,38 +1,29 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
-import { useHover } from '../../../../../packages/react-hooks/use-hover';
-// import { useHover } from "@nanlabs/react-hooks";
+import { useHover } from "@nanlabs/react-hooks";
 
 export const Example = () => {
-  const [isCbMemoBroken, setIsCbMemoBroken] = useState(false);
-  const [isTargetMemoBroken, setTargetMemoBroken] = useState(false);
+  const [isMemoEnabled, setIsMemoEnabled] = useState(false);
+  const [isRefTarget, setIsRefTarget] = useState(false);
   const [events, setEvents] = useState<string[]>([])
 
   const getEventHandler = useCallback((eventName: string) => {
     return () => setEvents((events) => [...events, `"${eventName}" callback fired`])
   }, [setEvents])
 
-  const memoizedCallbacks = useMemo(
-    () => ({
-      onChange: getEventHandler('onChange'),
-      onLeave: getEventHandler('onLeave'),
-      onEnter: getEventHandler('onEnter'),
-    }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [getEventHandler, isCbMemoBroken]
-  )
-
   const notMemoizedCallbacks = {
     onChange: getEventHandler('onChange'),
     onLeave: getEventHandler('onLeave'),
     onEnter: getEventHandler('onEnter'),
   }
+
+  const memoizedCallbacks = useMemo(() => ({...notMemoizedCallbacks}), [getEventHandler, isMemoEnabled])
   
   const divRef = useRef<HTMLDivElement | null>(null)
-  const getEl = () => divRef.current;
+  const getElement = () => divRef.current;
 
   const isHovered = useHover(
-    isTargetMemoBroken ? getEl : divRef,
-    isCbMemoBroken ? notMemoizedCallbacks : memoizedCallbacks
+    isRefTarget ? divRef : getElement,
+    isMemoEnabled ? memoizedCallbacks : notMemoizedCallbacks
   );
 
   const hoverableStyles = {
@@ -54,14 +45,14 @@ export const Example = () => {
       </h2>
 
       <span>
-        <button onClick={() => setIsCbMemoBroken((val) => !val)}>
-          {isCbMemoBroken ? 'Callbacks change each render' : 'Callbacks memoized'}
+        <button onClick={() => setIsMemoEnabled((val) => !val)}>
+          {isMemoEnabled ? 'Callbacks memoized' : 'Callbacks change each render'}
         </button>
       </span>
 
       <span>
-        <button onClick={() => setTargetMemoBroken((val) => !val)}>
-          {isTargetMemoBroken ? 'Target provided as function' : 'Target provided as ref'}
+        <button onClick={() => setIsRefTarget((val) => !val)}>
+          {isRefTarget ? 'Target provided as ref' : 'Target provided as function'}
         </button>
       </span>
     </div>

--- a/packages/react-hooks/index.ts
+++ b/packages/react-hooks/index.ts
@@ -13,3 +13,4 @@ export * from "./use-queue";
 export * from "./use-append-task";
 export * from "./use-copy-to-clipboard";
 export * from "./use-previous";
+export * from "./use-hover";

--- a/packages/react-hooks/use-hover/index.ts
+++ b/packages/react-hooks/use-hover/index.ts
@@ -1,0 +1,1 @@
+export { default as useHover } from "./useHover";

--- a/packages/react-hooks/use-hover/useHover.ts
+++ b/packages/react-hooks/use-hover/useHover.ts
@@ -1,0 +1,72 @@
+import { useEffect, type MutableRefObject, useState, useCallback, useRef } from 'react';
+
+type TargetValue<T> = T | undefined | null;
+
+type TargetType = HTMLElement | Element | Window | Document;
+
+export type HoverTarget<T extends TargetType = Element> =
+  | (() => TargetValue<T>)
+  | TargetValue<T>
+  | MutableRefObject<TargetValue<T>>;
+
+export interface Options {
+  onEnter?: () => void;
+  onLeave?: () => void;
+  onChange?: (isHovering: boolean) => void;
+}
+
+const useHover = <T extends TargetType = Element>(target: HoverTarget<T>, options?: Options): boolean => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const onMouseEnter = useCallback(() => {
+    const isHovered = true;
+    setIsHovered(isHovered)
+    options?.onChange?.(isHovered);
+    options?.onEnter?.()
+  }, [options?.onEnter])
+  
+  const onMouseLeave = useCallback(() => {
+    const isHovered = false;
+    setIsHovered(isHovered)
+    options?.onChange?.(isHovered);
+    options?.onLeave?.()
+  }, [options?.onLeave])
+
+  const prevCallbacks = useRef({ onMouseEnter, onMouseLeave });
+
+  useEffect(() => {
+    if (
+      !target ||
+      typeof window === 'undefined' ||
+      window?.matchMedia("(any-hover: none)").matches
+    ) {
+      return;
+    }
+    let targetEl: TargetValue<T>;
+    
+    
+    if (typeof target === 'function') {
+      targetEl = target()
+    } else if ('current' in target) {
+      targetEl = target.current;
+    }
+
+    if (!targetEl) {
+      return;
+    }
+
+    targetEl?.addEventListener('mouseenter', onMouseEnter)
+    targetEl?.addEventListener('mouseleave', onMouseLeave)
+    
+    // clean up previous listeners
+    prevCallbacks.current = { onMouseEnter, onMouseLeave }
+    return () => {
+      targetEl?.removeEventListener('mouseenter', prevCallbacks.current.onMouseEnter)
+      targetEl?.removeEventListener('mouseleave', prevCallbacks.current.onMouseLeave)
+    }
+  }, [target, onMouseEnter, onMouseLeave])
+  
+  return isHovered;
+};
+
+export default useHover

--- a/packages/react-hooks/use-hover/useHover.ts
+++ b/packages/react-hooks/use-hover/useHover.ts
@@ -23,14 +23,14 @@ const useHover = <T extends TargetType = Element>(target: HoverTarget<T>, option
     setIsHovered(isHovered)
     options?.onChange?.(isHovered);
     options?.onEnter?.()
-  }, [options?.onEnter])
+  }, [options?.onEnter, options?.onChange])
   
   const onMouseLeave = useCallback(() => {
     const isHovered = false;
     setIsHovered(isHovered)
     options?.onChange?.(isHovered);
     options?.onLeave?.()
-  }, [options?.onLeave])
+  }, [options?.onLeave, options?.onChange])
 
   const prevCallbacks = useRef({ onMouseEnter, onMouseLeave });
 
@@ -42,27 +42,27 @@ const useHover = <T extends TargetType = Element>(target: HoverTarget<T>, option
     ) {
       return;
     }
-    let targetEl: TargetValue<T>;
+    let targetElement: TargetValue<T>;
     
     
     if (typeof target === 'function') {
-      targetEl = target()
+      targetElement = target()
     } else if ('current' in target) {
-      targetEl = target.current;
+      targetElement = target.current;
     }
 
-    if (!targetEl) {
+    if (!targetElement) {
       return;
     }
 
-    targetEl?.addEventListener('mouseenter', onMouseEnter)
-    targetEl?.addEventListener('mouseleave', onMouseLeave)
+    targetElement?.addEventListener('mouseenter', onMouseEnter)
+    targetElement?.addEventListener('mouseleave', onMouseLeave)
     
     // clean up previous listeners
     prevCallbacks.current = { onMouseEnter, onMouseLeave }
     return () => {
-      targetEl?.removeEventListener('mouseenter', prevCallbacks.current.onMouseEnter)
-      targetEl?.removeEventListener('mouseleave', prevCallbacks.current.onMouseLeave)
+      targetElement?.removeEventListener('mouseenter', prevCallbacks.current.onMouseEnter)
+      targetElement?.removeEventListener('mouseleave', prevCallbacks.current.onMouseLeave)
     }
   }, [target, onMouseEnter, onMouseLeave])
   


### PR DESCRIPTION
# What's this PR do?

This PR adds `useHover` hook (issue #94) and a story for ease of review. Since other stories rely on imports from the published packages I suggest reviewing PR as is and changing the import path after that.

@ulises-jeremias @rpmolina




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Feature:**
- Added a new `useHover` custom hook in the `@nanlabs/react-hooks` library. This hook allows tracking the hover state of a target element and provides optional callback functions for hover events.
- Introduced an interactive `Example` component in the playground app to demonstrate the usage of the `useHover` hook. The component changes its appearance based on hover state and allows toggling of memoization and target type.

**Refactor:**
- Updated the exports in the `react-hooks` package to include the new `useHover` module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->