### PR TITLE
ci: harden Danger PR validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,8 @@ jobs:
   pr-review:
     if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     name: Pull Request Validation
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
     uses: nanlabs/devops-reference/.github/workflows/pr-review.yml@main

--- a/packages/react-ui/README.md
+++ b/packages/react-ui/README.md
@@ -26,9 +26,9 @@ npm install @nanlabs/react-ui
 
 ## Usage
 
-The following example shows how one of the multiple hooks provided by this library can be used.
+The following example shows how one of the components provided by this library can be used.
 
-In the example bellow we use the `Image` component to render an image with a list of fallbacks and retrying on error.
+In the example below we use the `Image` component to render an image with a list of fallbacks and retrying on error.
 
 You can find more examples in the [documentation][docs].
 

--- a/tools/danger/dangerfile.ts
+++ b/tools/danger/dangerfile.ts
@@ -5,6 +5,17 @@ const SMALL_PR_LINES = 200;
 
 const DOC_FILE_MATCH = "**/*.md";
 const SRC_FILE_REGEXP = /test.*\.([tj]s?)$/;
+const prBody = danger.github.pr.body ?? "";
+const releasePrTitle = /^(version packages|chore: version packages|chore\(release\):|chore: release\b)/i;
+
+const hasIssueReference = (text: string) => {
+  const cleaned = text
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/#ISSUE\b/gi, "");
+  const issueReference =
+    /\b(?:closes|fixes|resolves|refs|see|related to|part of)\s+(?:#\d+|https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)|(?<![#\w])#\d+\b/gim;
+  return issueReference.test(cleaned);
+};
 
 // No PR is too small to include a description of why you made a change
 if (
@@ -23,6 +34,21 @@ if (!danger.github.pr.title) {
   const title = ":id: Missing PR Title";
   const idea = "Can you add the relevant title?";
   warn(`${title} - <i>${idea}</i>`);
+}
+
+const isIssueReferenceExempt =
+  danger.github.pr.user.login.endsWith("[bot]") ||
+  danger.github.pr.user.login.startsWith("app/") ||
+  releasePrTitle.test(danger.github.pr.title ?? "");
+
+if (
+  !isIssueReferenceExempt &&
+  !hasIssueReference(prBody) &&
+  !hasIssueReference(danger.github.pr.title ?? "")
+) {
+  fail(
+    "This PR does not reference an issue. Please link the related issue with `Closes #N` or `Refs #N` in the PR description. If no issue exists, open one first so maintainers can review the change context."
+  );
 }
 
 const touchedFiles = danger.git.created_files.concat(danger.git.modified_files);


### PR DESCRIPTION
## Description
Harden the public DangerJS validation baseline for contributor PRs.

Refs #129

## Type of Change
- CI maintenance

## How Has This Been Tested?
- `rtk tsc --noEmit --moduleResolution node --module commonjs --target es2020 --skipLibCheck dangerfile.ts` from `tools/danger`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml`\n- `git diff --check`\n- Code review and security review subagents\n\n## Checklist\n- [x] My code follows the style guidelines of this project\n- [x] I have performed a self-review of my code\n- [x] I have commented my code, particularly in hard-to-understand areas\n- [x] I have made corresponding changes to the documentation\n- [x] My changes generate no new warnings\n- [x] Any dependent changes have been merged and published in downstream modules\n- [x] I have checked my code and corrected any misspellings