### PR TITLE
fix(fp): resolve turbo v2 schema errors + lint DEBUG declaration

### DIFF
--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -7,4 +7,16 @@ module.exports = {
     node: true,
     es2020: true,
   },
+  rules: {
+    // Allow plain (non-PROCESS_ENV-style) env vars that are intentionally
+    // read via `process.env.${name}` but aren't declared in any turbo.json
+    // (the eslint-plugin-turbo rule treats them as "undeclared dependencies").
+    // Format: `${name}` matches when the code references `process.env.${name}`.
+    "turbo/no-undeclared-env-vars": [
+      "error",
+      {
+        allowList: ["^DEBUG$"],
+      },
+    ],
+  },
 };

--- a/packages/fp/turbo.json
+++ b/packages/fp/turbo.json
@@ -1,4 +1,8 @@
 {
   "extends": ["//"],
-  "globalEnv": ["DEBUG"]
+  "tasks": {
+    "lint": {
+      "env": ["DEBUG"]
+    }
+  }
 }

--- a/packages/fp/turbo.json
+++ b/packages/fp/turbo.json
@@ -2,7 +2,8 @@
   "extends": ["//"],
   "tasks": {
     "lint": {
-      "env": ["DEBUG"]
+      "env": ["DEBUG"],
+      "passThroughEnv": ["DEBUG"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turbo.build/schema-v2.json",
   "globalDependencies": ["**/.env.*local"],
+  "globalEnv": ["DEBUG"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

Two CI failures originating in `packages/fp/turbo.json` and the shared ESLint config — both fixed in one PR.

### Issue 1 — `turbo_json_parse_error` (Typecheck + Linter fail since 2026-07-16T01:57Z)

The `packages/fp/turbo.json` file used `globalEnv: ["DEBUG"]`, which is **not a valid key at the package level** in Turborepo v2. `globalEnv` is only valid in the root `turbo.json`.

The error surfaced as:
```
×
× Failed to parse turbo.json.
`->   × Found an unknown key `globalEnv`.
       ,-[packages/fp/turbo.json:3:3]
       2 |   "extends": ["//"],
       3 |   "globalEnv": ["DEBUG"]
         `----
```

This blocked both `Typecheck` and `Linter` jobs on `main` and any PR that touched `packages/fp/**`.

### Issue 2 — `turbo/no-undeclared-env-vars` (after fixing #1)

After moving `DEBUG` to the root `globalEnv`, ESLint's `turbo/no-undeclared-env-vars` rule still flagged `process.env.DEBUG` at `packages/fp/guards/index.ts:25` because the eslint rule only looks at the workspace-level schema for env declarations.

Two changes here:

1. Re-declared the env at the LINT task in the local package:
   ```jsonc
   {
     "extends": ["//"],
     "tasks": {
       "lint": {
         "env": ["DEBUG"],
         "passThroughEnv": ["DEBUG"]
       }
     }
   }
   ```

2. Belt-and-braces: also added an allowList for `DEBUG` in the shared ESLint config (`packages/eslint-config-base/index.js`) so that if any other non-turbo package elsewhere references `process.env.DEBUG` it doesn't trip the rule.

```js
"turbo/no-undeclared-env-vars": ["error", { allowList: ["^DEBUG$"] }]
```

### Verification

- Latest CI (run 29518671728 at 2026-07-16T16:59 UTC) ✅ all checks green:
  - Linter / linter         — SUCCESS
  - Typecheck / type-check  — SUCCESS
  - Shellcheck / Shellcheck — SUCCESS
  - Markdownlint            — SUCCESS
  - CodeQL                  — SUCCESS (2 analyses)
  - pr-review / Danger      — SUCCESS

Closes the long-running Linter + Typecheck 🟥 on `main` and unblocks PRs targeting this package.